### PR TITLE
feat(ime): configure fcitx5 with rime-wanxiang from archlinuxcn (#5)

### DIFF
--- a/dotfiles/.config/fcitx5/conf/notifications.conf
+++ b/dotfiles/.config/fcitx5/conf/notifications.conf
@@ -1,3 +1,3 @@
-# 隐藏通知
-HiddenNotifications=
+# Hidden Notifications
+# HiddenNotifications=
 

--- a/dotfiles/.config/fcitx5/profile
+++ b/dotfiles/.config/fcitx5/profile
@@ -10,13 +10,13 @@ DefaultIM=keyboard-us
 # Name
 Name=rime
 # Layout
-Layout=
+# Layout=
 
 [Groups/0/Items/1]
 # Name
 Name=keyboard-us
 # Layout
-Layout=
+# Layout=
 
 [GroupOrder]
 0=Default

--- a/mise/conf.d/10-bootstrap.toml
+++ b/mise/conf.d/10-bootstrap.toml
@@ -3,7 +3,10 @@
 [bootstrap.packages]
 "pacman:android-tools" = "latest"
 "pacman:android-udev" = "latest"
+"pacman:fcitx5-configtool" = "latest"
+"pacman:fcitx5-rime" = "latest"
 "pacman:noise-suppression-for-voice" = "latest"
+"pacman:rime-wanxiang-pinyin" = "latest"
 "pacman:ttf-sarasa-gothic" = "latest"
 "pacman:unzip" = "latest"
 "pacman:yay" = "latest"

--- a/mise/tasks/archlinuxcn
+++ b/mise/tasks/archlinuxcn
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#MISE description="Configure archlinuxcn repository and install archlinuxcn-keyring"
+set -euo pipefail
+
+if [[ $EUID -eq 0 ]]; then
+    SUDO=""
+elif command -v sudo &>/dev/null && [[ -t 0 ]]; then
+    SUDO="sudo"
+elif command -v pkexec &>/dev/null; then
+    SUDO="pkexec"
+elif command -v sudo &>/dev/null; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+# 1. Configure [archlinuxcn] in /etc/pacman.conf if not already present
+if ! grep -q '^\s*\[archlinuxcn\]' /etc/pacman.conf; then
+    printf 'archlinuxcn: adding repository to /etc/pacman.conf\n'
+    cat <<'EOF' | $SUDO tee -a /etc/pacman.conf >/dev/null
+
+[archlinuxcn]
+Server = https://mirrors.ustc.edu.cn/archlinuxcn/$arch
+Server = https://repo.archlinuxcn.org/$arch
+EOF
+else
+    printf 'archlinuxcn: repository entry already present in /etc/pacman.conf\n'
+fi
+
+# 2. Install archlinuxcn-keyring if not already installed
+if ! pacman -Q archlinuxcn-keyring &>/dev/null; then
+    printf 'archlinuxcn: installing archlinuxcn-keyring\n'
+    tmp_pkg="$(mktemp --suffix=.pkg.tar.zst)"
+    curl -sSL "https://mirrors.ustc.edu.cn/archlinuxcn/x86_64/archlinuxcn-keyring-20260505-1-any.pkg.tar.zst" -o "$tmp_pkg"
+    $SUDO pacman -U --needed --noconfirm "$tmp_pkg"
+    rm -f "$tmp_pkg"
+    $SUDO pacman -Sy
+else
+    printf 'archlinuxcn: archlinuxcn-keyring is already installed\n'
+fi

--- a/mise/tasks/bootstrap
+++ b/mise/tasks/bootstrap
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Apply post-bootstrap setup"
-#MISE depends=["aur", "wps", "hardware"]
+#MISE depends=["archlinuxcn", "aur", "wps", "hardware"]
 set -euo pipefail
 
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"


### PR DESCRIPTION
Closes #5

### Implementation Tasks
- [x] 1. Configure archlinuxcn repository and keyring initialization
- [x] 2. Declare fcitx5-rime and rime-wanxiang-pinyin in bootstrap packages
- [x] 3. Sync fcitx5 profile, build rime deployment, and verify IME functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic setup for the Arch Linux CN repository and its signing key.
  - Added Fcitx5 configuration tools and Rime input method packages to system bootstrapping.
  - Bootstrap setup now includes Arch Linux CN repository configuration.

- **Configuration**
  - Updated Fcitx5 input method layout settings to preserve default layout behavior for Rime and US keyboard input.
  - Translated notification configuration comments into English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->