### PR TITLE
feat(rime): switch wanxiang schema to flypy double pinyin (#9)

### DIFF
--- a/mise/conf.d/10-bootstrap.toml
+++ b/mise/conf.d/10-bootstrap.toml
@@ -6,7 +6,7 @@
 "pacman:fcitx5-configtool" = "latest"
 "pacman:fcitx5-rime" = "latest"
 "pacman:noise-suppression-for-voice" = "latest"
-"pacman:rime-wanxiang-pinyin" = "latest"
+"pacman:rime-wanxiang-flypy" = "latest"
 "pacman:ttf-sarasa-gothic" = "latest"
 "pacman:unzip" = "latest"
 "pacman:yay" = "latest"


### PR DESCRIPTION
Closes #9

### Implementation Tasks
- [x] 1. Replace rime-wanxiang-pinyin with rime-wanxiang-flypy in bootstrap packages
- [x] 2. Deploy flypy schema, build rime deployment, and restart fcitx5 service