### PR TITLE
feat(bootstrap): use prebuilt wezterm-git from archlinuxcn (#11)

### DIFF
--- a/mise/conf.d/10-bootstrap.toml
+++ b/mise/conf.d/10-bootstrap.toml
@@ -9,6 +9,9 @@
 "pacman:rime-wanxiang-flypy" = "latest"
 "pacman:ttf-sarasa-gothic" = "latest"
 "pacman:unzip" = "latest"
+# Official extra/wezterm (2024-02) fails to map windows on Hyprland 0.56 Wayland;
+# archlinuxcn ships a current enough build. Conflicts with pacman:wezterm.
+"pacman:wezterm-git" = "latest"
 "pacman:yay" = "latest"
 # VAAPI 硬编驱动——仅本机（Intel Sandy Bridge i965）需要；其他硬件请按需取消注释
 # "pacman:libva-intel-driver" = "latest"

--- a/mise/tasks/aur
+++ b/mise/tasks/aur
@@ -12,7 +12,6 @@ packages=(
     ttf-wps-fonts
     unibarrage-bin
     wechat-appimage
-    wezterm-git
     wps-office-365-edu
     wps-office-365-edu-fonts
 )


### PR DESCRIPTION
Closes #11

### Implementation Tasks
- [x] 1. Move wezterm-git from mise/tasks/aur back to mise/conf.d/10-bootstrap.toml
- [x] 2. Install prebuilt wezterm-git package and validate task status