### PR TITLE
refactor: decouple omarchy dependencies and establish suckless principles (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions & Project Guidelines
 
-This repository is the single source of truth for a personal Arch Linux + Omarchy desktop environment.
+This repository is the single source of truth for a personal Arch Linux desktop environment adhering to Suckless and Unix philosophies (see `PRINCIPLES.md`).
 
 ---
 
@@ -13,11 +13,9 @@ Always edit source files within this repository. The `~/.config` and `~/.local` 
 | Repo dev tools & linters | `mise.toml` → `[tools]` |
 | Machine packages & system hooks | `mise/conf.d/10-bootstrap.toml` |
 | Dotfile symlink mappings | `mise/conf.d/20-dotfiles.toml` |
-| AUR packages | `mise/tasks/aur` |
 | System bootstrap logic | `mise/tasks/bootstrap` |
-| Hyprland configuration | `dotfiles/.config/hypr/*.lua` |
-| Omarchy shell & bar plugins | `dotfiles/.config/omarchy/plugins/` |
-| Shell layout & widget settings | `dotfiles/.config/omarchy/shell.json` |
+| Window manager & compositor | `dotfiles/.config/river/` / `dotfiles/.config/hypr/` |
+| State collectors & CLI tools | `dotfiles/.local/bin/` |
 | Dotfile sources | `dotfiles/` (never edit target symlinks directly) |
 
 ---
@@ -107,32 +105,20 @@ Supported formatters and linters:
 
 ---
 
-## 5. Omarchy Shell & Plugin Development Standards
+## 5. System Architecture & Suckless Standards
 
-Omarchy desktop runs inside a single long-lived Quickshell process (`omarchy-shell`).
+This system follows the principles documented in `PRINCIPLES.md`:
 
-1. **System Boundaries**:
-   - `/usr/share/omarchy/` is **read-only** (managed by system package). Never modify files here.
-   - User plugins live under `dotfiles/.config/omarchy/plugins/<plugin-id>/`.
-2. **Namespace Isolation**:
-   - `omarchy.*` is reserved for official built-ins.
-   - User plugins must use `<username>.<plugin-id>` (e.g. `dotfiles/.config/omarchy/plugins/xifan.*`).
-   - To customize a built-in widget, clone it with `omarchy plugin clone omarchy.<id>`.
-3. **Collector / Display Separation**:
-   - **QML UI**: Pure presentation. Read state reactively via `FileView { watchChanges: true }` from `$XDG_STATE_HOME/omarchy/` JSON files. Never block QML with heavy compute or network requests.
-   - **Collectors / Daemons**: Heavy polling, API calls, and hardware sensors belong in separate Python/Bash scripts.
-   - **Atomic Writes**: Collectors must write state files to a temporary file in the same filesystem first, then atomically replace (`os.replace` / `mv`) to prevent Quickshell from reading incomplete JSON.
-4. **IPC Contract & Multi-Monitor**:
-   - Summon or toggle overlays: `omarchy-shell shell summon|toggle <id> '<jsonPayload>'`.
-   - Multi-monitor sync: Use `BarWidget.broadcast(method)` to refresh instances across all screens.
-   - String boolean typing: IPC boolean arguments must be the literal string `"true"` (all other strings are evaluated as `false`).
-5. **Configuration (`shell.json`)**:
-   - Layout and widget instances are persisted flatly in `dotfiles/.config/omarchy/shell.json`.
-   - Settings are inline on each entry (no nested `config:` objects). A third-party plugin is enabled if and only if its entry exists in `shell.json`.
-6. **Reloading & Debugging**:
-   - Prefer `omarchy restart shell` during active plugin development to guarantee clean QML/JS module caches.
-   - Use `omarchy-shell shell rescanPlugins` for lightweight metadata/new plugin discovery.
-   - View live runtime logs: `journalctl --user -b -f | grep -iE "quickshell|omarchy"`.
+1. **Self-Containment & Zero External Framework Lock-in**:
+   - Never reference `/usr/share/omarchy/` or rely on proprietary distribution hooks.
+   - All desktop logic, keybindings, and theme pipelines must reside self-contained within this repository.
+2. **Collector / Display Separation**:
+   - **Display UI**: Pure presentation (e.g. Waybar, minimal river client). Read state reactively from `$XDG_RUNTIME_DIR/state/` JSON files. Never perform heavy compute, blocking I/O, or network polling in UI components.
+   - **Collectors / Daemons**: Polling, sensor queries, hardware state, and API sync belong in standalone scripts under `dotfiles/.local/bin/` managed by user timers or background services.
+   - **Atomic Writes**: Collectors must write state files to a temporary file on the same filesystem first, then atomically replace (`os.replace` / `mv`) to guarantee that consumers never read incomplete or corrupted state.
+3. **Suckless Frugality**:
+   - Favor minimal C / Zig / POSIX Shell components over bloated GUI wrappers or multi-megabyte daemon frameworks.
+   - Mechanism over policy: The window manager and shell should remain strictly within the user's cognitive control.
 
 ---
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,58 @@
+# Project Principles & Architectural Manifesto
+
+> **Core Purpose**: To build and govern a personal Arch Linux desktop environment adhering strictly to **Suckless** and **Unix** philosophies: lightweight, transparent, self-contained, and fully owned by the user.
+
+---
+
+## 1. Unix Philosophy in Desktop Governance
+
+### 1.1 Single Responsibility (Do One Thing and Do It Well)
+- **Compositor vs. Window Manager Separation**:
+  - The compositor (e.g. River) strictly manages hardware rendering, output, and low-level Wayland protocol handling.
+  - The window manager (a dedicated client) strictly manages layout policy, focus, and keybindings.
+- **Collector / Display Separation**:
+  - Data collectors (daemons, polling scripts for GPU, fan, livestream, token quotas) only gather data and atomically write standard JSON files to `$XDG_RUNTIME_DIR/state/*.json`. They never touch UI.
+  - Presentation interfaces (status bars, OSDs, notifications) only read state files reactively. They never perform heavy blocking compute or network requests in the UI thread.
+
+### 1.2 Composition Over Integration
+- Avoid monolithic desktop frameworks or proprietary IPC systems with hidden abstractions.
+- All inter-component communication relies on open, universal mechanisms:
+  - Standard Wayland extension protocols (e.g., `river-window-management-v1`).
+  - Kernel and userspace virtual filesystems (`/sys`, `/proc`, `/run`).
+  - POSIX pipes, standard signals, and atomic file replacements.
+
+### 1.3 Text as the Universal Interface
+- All internal communication, palette definitions, and configuration fragments must use human-readable formats (TOML, INI, JSON, or plain key-value text).
+- State and diagnostics must be inspectable, filterable, and replayable using standard utilities (`cat`, `grep`, `jq`).
+
+---
+
+## 2. Suckless Philosophy in Architecture
+
+### 2.1 Mechanism Over Policy
+- The system core provides mechanism; user code determines policy.
+- No upstream framework may impose non-negotiable default behaviors or proprietary bindings.
+
+### 2.2 Cognitive Maintainability (Clarity Over Cleverness)
+- **Minimal footprint**: If a task can be accomplished with a 50-line POSIX shell script, do not introduce a heavy background daemon or complex runtime.
+- **Understandability**: The entire system configuration and supporting tooling should remain small enough that the user can understand and maintain every single line.
+
+### 2.3 Zero Bloat & Resource Frugality
+- **Minimalist infrastructure**: Prefer `iwd` + `systemd-networkd` + `systemd-resolved` over heavyweight network managers with dozens of background dependencies.
+- **Lightweight terminals**: Choose terminals that cold-boot in milliseconds with minimal base memory (< 10 MB per instance), avoiding bloated GPU compute pipelines for simple text rendering.
+- **On-demand execution**: Avoid persistent polling daemons where systemd user timers, socket activation, or event hooks suffice.
+
+---
+
+## 3. Engineering & Delivery Standards
+
+### 3.1 Absolute Self-Containment & Portability
+- The repository must not depend on non-standard directories (such as `/usr/share/omarchy/`).
+- A freshly installed vanilla Arch Linux machine must be able to bootstrap the full environment cleanly via `mise bootstrap`.
+
+### 3.2 Declarative & Strictly Idempotent
+- Packages must be declared natively (using mise `pacman:` and `aur:` providers).
+- Running the bootstrap sequence once or a hundred times must yield an identical, converged state with zero side-effects.
+
+### 3.3 Local-First & Resilient
+- The core desktop experience, window management, terminal, and Chinese IME (Fcitx5 + Rime Xiaohe Double Pinyin) must operate 100% offline without external network dependencies.

--- a/dotfiles/.config/hypr/bindings.lua
+++ b/dotfiles/.config/hypr/bindings.lua
@@ -1,5 +1,5 @@
--- Personal keybindings on top of Omarchy defaults.
--- View the effective bindings with: omarchy menu keybindings --print
+-- Personal keybindings on top of personal defaults.
+-- [DEPRECATED / MIGRATION]: Proprietary command wrappers being transitioned to standard utilities.
 
 -- ============================================================================
 -- Daily Applications (Win = primary, Win+Alt = secondary variant)
@@ -8,13 +8,13 @@ hl.unbind("SUPER + RETURN")
 o.bind(
   "SUPER + RETURN",
   "Terminal",
-  [[uwsm-app -- wezterm start --cwd "$(omarchy-cmd-terminal-cwd)"]]
+  [[uwsm-app -- wezterm start --cwd "$(command -v omarchy-cmd-terminal-cwd >/dev/null 2>&1 && omarchy-cmd-terminal-cwd || echo "$HOME")"]]
 )
 hl.unbind("SUPER + ALT + RETURN")
 o.bind(
   "SUPER + ALT + RETURN",
   "Herdr",
-  [[uwsm-app -- wezterm start --cwd "$(omarchy-cmd-terminal-cwd)" -- herdr]]
+  [[uwsm-app -- wezterm start --cwd "$(command -v omarchy-cmd-terminal-cwd >/dev/null 2>&1 && omarchy-cmd-terminal-cwd || echo "$HOME")" -- herdr]]
 )
 
 -- Browser (B)

--- a/dotfiles/.config/hypr/hyprland.lua
+++ b/dotfiles/.config/hypr/hyprland.lua
@@ -1,16 +1,21 @@
 -- Learn how to configure Hyprland: https://wiki.hypr.land/Configuring/Start/
 
--- Omarchy's bootstrap keeps path setup out of this user config.
-dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")
+-- [DEPRECATED / MIGRATION]: External Omarchy bootstrap layer.
+-- Planned for replacement with self-contained native config / River 0.4 session.
+local omarchy_bootstrap = (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy")
+  .. "/default/hypr/bootstrap.lua"
+local f = io.open(omarchy_bootstrap, "r")
+if f then
+  f:close()
+  dofile(omarchy_bootstrap)
+  pcall(require, "default.hypr.omarchy")
+  pcall(require, "default.hypr.toggles")
+end
 
--- Load Omarchy defaults, then apply personal overrides from this repository.
-require("default.hypr.omarchy")
+-- Personal configuration modules
 require("hypr.monitors")
 require("hypr.input")
 require("hypr.bindings")
 require("hypr.looknfeel")
 require("hypr.autostart")
 require("hypr.windows")
-
--- Toggle config flags dynamically.
-require("default.hypr.toggles")

--- a/dotfiles/.config/systemd/user/fcitx5.service.d/override.conf
+++ b/dotfiles/.config/systemd/user/fcitx5.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/fcitx5

--- a/dotfiles/.local/bin/fcitx5-theme-sync
+++ b/dotfiles/.local/bin/fcitx5-theme-sync
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Sync and generate fcitx5 custom theme from global palette with zero external dependencies
+set -euo pipefail
+
+config_theme="${XDG_CONFIG_HOME:-$HOME/.config}/theme/colors.toml"
+state_theme="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/current/theme/colors.toml"
+
+if [[ -f "$config_theme" ]]; then
+	colors_file="$config_theme"
+elif [[ -f "$state_theme" ]]; then
+	colors_file="$state_theme"
+else
+	colors_file=""
+fi
+
+get_color() {
+	local key="$1" default="$2"
+	if [[ -n "$colors_file" && -f "$colors_file" ]]; then
+		local val
+		val="$(grep -E "^${key}\s*=" "$colors_file" | head -1 | cut -d'"' -f2 || true)"
+		if [[ -n "$val" ]]; then
+			printf '%s' "$val"
+			return 0
+		fi
+	fi
+	printf '%s' "$default"
+}
+
+blend() {
+	local base="${1#\#}" over="${2#\#}" ratio="$3"
+	local br=$((16#${base:0:2})) bg=$((16#${base:2:2})) bb=$((16#${base:4:2}))
+	local or=$((16#${over:0:2})) og=$((16#${over:2:2})) ob=$((16#${over:4:2}))
+	printf "#%02x%02x%02x" \
+		$((br + (or - br) * ratio / 100)) \
+		$((bg + (og - bg) * ratio / 100)) \
+		$((bb + (ob - bb) * ratio / 100))
+}
+
+background="$(get_color background '#1a1b26')"
+foreground="$(get_color foreground '#a9b1d6')"
+accent="$(get_color accent '#7aa2f7')"
+separator="$(get_color muted '#414868')"
+highlight_bg="$(blend "$background" "$accent" 18)"
+
+fcitx5_theme_dir="${XDG_DATA_HOME:-$HOME/.local/share}/fcitx5/themes/custom"
+fcitx5_theme_conf="$fcitx5_theme_dir/theme.conf"
+fcitx5_classicui="${XDG_CONFIG_HOME:-$HOME/.config}/fcitx5/conf/classicui.conf"
+
+mkdir -p "$fcitx5_theme_dir"
+
+cat >"$fcitx5_theme_conf" <<EOF
+[Metadata]
+Name=Custom
+ScaleWithDPI=True
+
+[InputPanel]
+Font=Sans 12
+NormalColor=$foreground
+HighlightCandidateColor=$accent
+HighlightColor=$foreground
+HighlightBackgroundColor=$highlight_bg
+PageButtonAlignment=Last Candidate
+
+[InputPanel/TextMargin]
+Left=5
+Right=5
+Top=5
+Bottom=5
+
+[InputPanel/ContentMargin]
+Left=2
+Right=2
+Top=2
+Bottom=2
+
+[InputPanel/Background]
+Color=$background
+BorderColor=$accent
+BorderWidth=2
+
+[InputPanel/Background/Margin]
+Left=2
+Right=2
+Top=2
+Bottom=2
+
+[InputPanel/Highlight]
+Color=$highlight_bg
+
+[InputPanel/Highlight/Margin]
+Left=5
+Right=5
+Top=5
+Bottom=5
+
+[InputPanel/PrevPage]
+Image=prev.svg
+
+[InputPanel/PrevPage/ClickMargin]
+Left=5
+Right=5
+Top=4
+Bottom=4
+
+[InputPanel/NextPage]
+Image=next.svg
+
+[InputPanel/NextPage/ClickMargin]
+Left=5
+Right=5
+Top=4
+Bottom=4
+
+[Menu]
+NormalColor=$foreground
+HighlightCandidateColor=$accent
+
+[Menu/ContentMargin]
+Left=2
+Right=2
+Top=2
+Bottom=2
+
+[Menu/Background]
+Color=$background
+BorderColor=$accent
+BorderWidth=2
+
+[Menu/Background/Margin]
+Left=2
+Right=2
+Top=2
+Bottom=2
+
+[Menu/CheckBox]
+Image=radio.svg
+
+[Menu/SubMenu]
+Image=arrow.svg
+
+[Menu/Highlight]
+Color=$highlight_bg
+
+[Menu/Highlight/Margin]
+Left=5
+Right=5
+Top=5
+Bottom=5
+
+[Menu/Separator]
+Color=$separator
+
+[Menu/TextMargin]
+Left=5
+Right=5
+Top=5
+Bottom=5
+EOF
+
+for svg in arrow.svg next.svg prev.svg radio.svg; do
+	if [[ -f "/usr/share/fcitx5/themes/default/$svg" && ! -e "$fcitx5_theme_dir/$svg" ]]; then
+		ln -sf "/usr/share/fcitx5/themes/default/$svg" "$fcitx5_theme_dir/$svg"
+	fi
+done
+
+if [[ ! -f "$fcitx5_classicui" ]]; then
+	mkdir -p "$(dirname "$fcitx5_classicui")"
+	cat >"$fcitx5_classicui" <<'EOF'
+Vertical Candidate List=False
+Font=Sans 12
+Theme=custom
+EOF
+fi
+
+if systemctl --user is-active --quiet fcitx5.service 2>/dev/null; then
+	systemctl --user restart fcitx5.service
+elif systemctl --user is-active --quiet omarchy-fcitx5.service 2>/dev/null; then
+	systemctl --user restart omarchy-fcitx5.service
+elif pgrep -x fcitx5 >/dev/null; then
+	pkill -x fcitx5 && nohup /usr/bin/fcitx5 >/dev/null 2>&1 &
+fi

--- a/mise/conf.d/20-dotfiles.toml
+++ b/mise/conf.d/20-dotfiles.toml
@@ -29,7 +29,8 @@ dotfiles.default_mode = "symlink"
 "~/.config/mise" = { source = "../../dotfiles/.config/mise", mode = "symlink-each" }
 "~/.config/wezterm" = { source = "../../dotfiles/.config/wezterm", mode = "symlink-each" }
 "~/.config/nvim" = { source = "../../dotfiles/.config/nvim", mode = "symlink-each" }
-"~/.config/omarchy" = { source = "../../dotfiles/.config/omarchy", mode = "symlink-each" }
+# Omarchy configuration decoupled for suckless migration
+# "~/.config/omarchy" = { source = "../../dotfiles/.config/omarchy", mode = "symlink-each" }
 "~/.config/pipewire" = { source = "../../dotfiles/.config/pipewire", mode = "symlink-each" }
 "~/.config/qutebrowser" = { source = "../../dotfiles/.config/qutebrowser", mode = "symlink-each", exclude = [
   "*.example",

--- a/mise/tasks/bootstrap
+++ b/mise/tasks/bootstrap
@@ -24,23 +24,9 @@ seed_example dotfiles/.config/dmnotifier/config.yaml.example "$config_home/dmnot
 seed_example dotfiles/.config/vinput/config.json.example "$config_home/vinput/config.json" 0600
 seed_example dotfiles/.config/qutebrowser/translate.json.example "$config_home/qutebrowser/translate.json" 0600
 
-state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
-theme="$state_home/omarchy/current/theme/neovim.lua"
-target="$config_home/nvim/lua/plugins/theme.lua"
-
-if [[ -f "$theme" ]]; then
-    mkdir -p "$(dirname "$target")"
-    if [[ -L "$target" ]]; then
-        ln -sfn "$theme" "$target"
-    elif [[ ! -e "$target" ]]; then
-        ln -s "$theme" "$target"
-    else
-        printf 'bootstrap: preserving unmanaged file: %s\n' "$target" >&2
-    fi
-fi
-
-fcitx5_theme_hook="dotfiles/.config/omarchy/hooks/theme-set.d/fcitx5-sync.hook"
-if [[ -f "$fcitx5_theme_hook" ]]; then
-    printf 'bootstrap: initializing fcitx5 theme...\n'
-    bash "$fcitx5_theme_hook"
+# Sync fcitx5 theme in a standalone, self-contained way
+fcitx5_theme_sync="dotfiles/.local/bin/fcitx5-theme-sync"
+if [[ -x "$fcitx5_theme_sync" ]]; then
+    printf 'bootstrap: syncing fcitx5 theme...\n'
+    "$fcitx5_theme_sync"
 fi


### PR DESCRIPTION
Closes #13

### Implementation Tasks
- [x] 1. Establish project principles and update agent guidelines
- [x] 2. Clean up bootstrap tasks, dotfiles mappings, and systemd units
- [x] 3. Comment out external Omarchy bindings in Hyprland configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic Fcitx5 theme generation and synchronization from the active color palette.
  - Added reliable Fcitx5 service configuration and automatic restart handling after theme updates.

- **Bug Fixes**
  - Terminal shortcuts now fall back to the home directory when the optional working-directory helper is unavailable.
  - Personal Hyprland settings now load even when the optional system bootstrap is missing.

- **Documentation**
  - Added project principles covering Unix-style architecture, simplicity, maintainability, and local resilience.
  - Updated project documentation to reflect the current desktop architecture.

- **Chores**
  - Decoupled automatic configuration from the previous desktop environment integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->