### PR TITLE
refactor(skills): purify skills and remove obsolete framework references (#31)

### DIFF
--- a/.agents/skills/arch-dev/references/issue-pr-workflow.md
+++ b/.agents/skills/arch-dev/references/issue-pr-workflow.md
@@ -37,7 +37,7 @@ To maintain clear separation of concerns between functional task design and tool
                 |    mise run check:plan (preview steps)|
                 |    mise run check:changed             |
                 |    mise run fix (if needed)           |
-                |    Domain validations (Hypr/Omarchy)  |
+                |    Domain validations (Mise/River)    |
                 +-------------------+-------------------+
                                     |
                 +-------------------v-------------------+
@@ -111,22 +111,13 @@ For each unchecked `- [ ]` task in order:
    hk run check --safe --format jsonl
    ```
 3. **Domain-Specific Verification**:
-   - **Hyprland configs (`dotfiles/.config/hypr/*.lua`)**:
-     ```bash
-     hyprctl reload && hyprctl configerrors
-     ```
-   - **Omarchy shell plugins (`dotfiles/.config/omarchy/plugins/<name>/`)**:
-     ```bash
-     # Verify QML syntax
-     qmllint dotfiles/.config/omarchy/plugins/<name>/*.qml
-     # Rescan or restart shell
-     omarchy-shell shell rescanPlugins
-     # or full restart for clean QML engine cache:
-     omarchy restart shell
-     ```
    - **Mise tasks (`mise.toml`)**:
      ```bash
      mise tasks validate
+     ```
+   - **Mise bootstrap plan**:
+     ```bash
+     mise bootstrap plan
      ```
 4. **Local Atomic Commit**:
    Keep commits strictly atomic (one commit per `- [ ]` task) and keep them **local** during intermediate steps:

--- a/.agents/skills/arch-dev/references/principles.md
+++ b/.agents/skills/arch-dev/references/principles.md
@@ -47,7 +47,7 @@
 ## 3. Engineering & Delivery Standards
 
 ### 3.1 Absolute Self-Containment & Portability
-- The repository must not depend on non-standard directories (such as `/usr/share/omarchy/`).
+- All desktop configurations, scripts, and assets are fully self-contained within this repository and standard XDG locations (`$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_STATE_HOME`).
 - A freshly installed vanilla Arch Linux machine must be able to bootstrap the full environment cleanly via `mise bootstrap`.
 
 ### 3.2 Declarative & Strictly Idempotent

--- a/.agents/skills/arch-dev/references/workflows.md
+++ b/.agents/skills/arch-dev/references/workflows.md
@@ -86,13 +86,12 @@ Use whole-repo tasks only when doing batch repository audits or cleanups:
 | `vm:status`     | 2. VM Sandbox       | `mise.toml`            | Show testing VM status and snapshots               |
 | `vm:reset`      | 2. VM Sandbox       | `mise.toml`            | Revert testing VM to clean snapshot                |
 
-Commands may require `sudo`/`pkexec` for system-wide changes (e.g. AUR, `/etc`
-hooks). Follow the privilege rules in `omarchy.md`.
+Commands may require `sudo`/`pkexec` for system-wide changes (e.g. `/etc` files).
 
 ## Atomic writes and file watching
 
 Any daemon, collector, or background script that outputs status records
-watched by Quickshell / Omarchy plugins must write files atomically:
+watched by status bars (such as Waybar) must write files atomically:
 write to a temporary file in the same filesystem, then `os.replace` (or `mv`)
 into place. This eliminates partial reads or multi-process race conditions.
 

--- a/.agents/skills/arch-guide/references/dotfiles.md
+++ b/.agents/skills/arch-guide/references/dotfiles.md
@@ -53,16 +53,5 @@ first run only:
 - `dotfiles/.config/vinput/config.json.example` (mode 0600)
 - `dotfiles/.config/qutebrowser/translate.json.example` (mode 0600)
 
-`bootstrap` uses `install -D -m <mode>` and writes only when the file is
+`mise/hooks/post-dotfiles.sh` uses `install -D -m <mode>` and writes only when the file is
 **missing**, so it preserves an existing local config.
-
-## Dynamic theme link
-
-`bootstrap` also wires the Omarchy Neovim theme into nvim:
-
-```
-$XDG_STATE_HOME/omarchy/current/theme/neovim.lua
-  → ~/.config/nvim/lua/plugins/theme.lua
-```
-
-It preserves an existing unmanaged file rather than overwriting.

--- a/.agents/skills/arch-guide/references/related-projects.md
+++ b/.agents/skills/arch-guide/references/related-projects.md
@@ -1,6 +1,6 @@
 # Related Standalone Projects Index
 
-This repository (`arch-post-install`) is the central declarative kit for the personal Arch Linux + Omarchy desktop environment. Several specialized subsystems live in standalone repositories but integrate directly with components configured here.
+This repository (`arch-post-install`) is the central declarative kit for the personal Arch Linux + River desktop environment. Several specialized subsystems live in standalone repositories but integrate directly with components configured here.
 
 Use this index to understand architecture boundaries and locate the source of truth for external dependencies.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ All coding agents must strictly operate within this closed-loop chronological li
                 |    mise run check:plan (preview steps)|
                 |    mise run check:changed             |
                 |    mise run fix (if needed)           |
-                |    Domain validations (Hypr/Omarchy)  |
+                |    Domain validations (Mise/River)    |
                 +-------------------+-------------------+
                                     |
                 +-------------------v-------------------+
@@ -102,7 +102,6 @@ Supported formatters and linters:
 - **TOML**: `taplo` (with `--no-schema`)
 - **JSON / YAML**: `prettier`
 - **JavaScript**: `oxlint`
-- **QML**: `qmllint`
 - **Zsh**: `zsh -n` (syntax check), `shfmt` (format)
 
 ---
@@ -111,9 +110,8 @@ Supported formatters and linters:
 
 This system follows the principles documented in `.agents/skills/arch-dev/references/principles.md`:
 
-1. **Self-Containment & Zero External Framework Lock-in**:
-   - Never reference `/usr/share/omarchy/` or rely on proprietary distribution hooks.
-   - All desktop logic, keybindings, and theme pipelines must reside self-contained within this repository.
+1. **Self-Containment & Standard XDG Compliance**:
+   - All desktop logic, keybindings, and theme pipelines must reside self-contained within this repository and standard XDG locations.
 2. **Collector / Display Separation**:
    - **Display UI**: Pure presentation (e.g. Waybar, minimal river client). Read state reactively from `$XDG_RUNTIME_DIR/state/` JSON files. Never perform heavy compute, blocking I/O, or network polling in UI components.
    - **Collectors / Daemons**: Polling, sensor queries, hardware state, and API sync belong in standalone scripts under `dotfiles/.local/bin/` managed by user timers or background services.


### PR DESCRIPTION
Closes #31

### Implementation Tasks
- [x] 1. Clean up arch-dev references (issue-pr-workflow, workflows, principles) to eliminate obsolete framework references
- [x] 2. Clean up arch-guide references (dotfiles, related-projects) to reflect pure Arch Linux + River environment
- [x] 3. Update AGENTS.md to purge obsolete negative references
- [x] 4. Validate skill definitions and run quality gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development guidance to use Mise and River for domain validation.
  - Clarified self-containment requirements around repository and standard XDG locations.
  - Revised workflow guidance for privilege handling, atomic writes, and status-bar integration.
  - Updated dotfiles documentation to describe template seeding through the post-dotfiles hook.
  - Refreshed related-project documentation to describe the Arch Linux and River desktop environment.
  - Removed outdated Hyprland, Omarchy, QML linter, and dynamic theme-link references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->