### PR TITLE
feat(theme): build universal semantic theme engine for river desktop (#33)

### DIFF
--- a/dotfiles/.config/themed/fnott.ini.tpl
+++ b/dotfiles/.config/themed/fnott.ini.tpl
@@ -1,0 +1,11 @@
+# TARGET: ~/.config/fnott/theme.ini
+[main]
+background={{ background_strip }}f0
+border-color={{ accent_strip }}ff
+title-color={{ bright_foreground_strip }}ff
+summary-color={{ foreground_strip }}ff
+body-color={{ light_foreground_strip }}ff
+
+[critical]
+border-color={{ red_strip }}ff
+title-color={{ bright_red_strip }}ff

--- a/dotfiles/.config/themed/foot.ini.tpl
+++ b/dotfiles/.config/themed/foot.ini.tpl
@@ -1,0 +1,25 @@
+# TARGET: ~/.config/foot/theme.ini
+[colors]
+background={{ background_strip }}
+foreground={{ foreground_strip }}
+
+regular0={{ dark_background_strip }}
+regular1={{ red_strip }}
+regular2={{ green_strip }}
+regular3={{ yellow_strip }}
+regular4={{ blue_strip }}
+regular5={{ magenta_strip }}
+regular6={{ cyan_strip }}
+regular7={{ foreground_strip }}
+
+bright0={{ dark_foreground_strip }}
+bright1={{ bright_red_strip }}
+bright2={{ bright_green_strip }}
+bright3={{ bright_yellow_strip }}
+bright4={{ bright_blue_strip }}
+bright5={{ bright_magenta_strip }}
+bright6={{ bright_cyan_strip }}
+bright7={{ bright_foreground_strip }}
+
+selection-foreground={{ background_strip }}
+selection-background={{ accent_strip }}

--- a/dotfiles/.config/themed/fuzzel.ini.tpl
+++ b/dotfiles/.config/themed/fuzzel.ini.tpl
@@ -1,0 +1,8 @@
+# TARGET: ~/.config/fuzzel/theme.ini
+[colors]
+background={{ background_strip }}f2
+text={{ foreground_strip }}ff
+match={{ accent_strip }}ff
+selection={{ selection_strip }}ff
+selection-text={{ bright_foreground_strip }}ff
+border={{ accent_strip }}ff

--- a/dotfiles/.config/themed/river-borders.sh.tpl
+++ b/dotfiles/.config/themed/river-borders.sh.tpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# TARGET: ~/.config/river/theme.sh
+# Update River border colors and theme variables dynamically
+set -euo pipefail
+
+export RIVER_BORDER_FOCUSED="0x{{ accent_strip }}"
+export RIVER_BORDER_UNFOCUSED="0x{{ muted_strip }}"
+export RIVER_BORDER_URGENT="0x{{ red_strip }}"
+export RIVER_BACKGROUND="0x{{ background_strip }}"

--- a/dotfiles/.config/themed/waybar.css.tpl
+++ b/dotfiles/.config/themed/waybar.css.tpl
@@ -1,0 +1,16 @@
+/* TARGET: ~/.config/waybar/theme.css */
+@define-color bg {{ background }};
+@define-color bg_dark {{ dark_background }};
+@define-color bg_light {{ lighter_background }};
+@define-color fg {{ foreground }};
+@define-color fg_dark {{ dark_foreground }};
+@define-color fg_bright {{ bright_foreground }};
+@define-color accent {{ accent }};
+@define-color selection {{ selection }};
+@define-color muted {{ muted }};
+@define-color red {{ red }};
+@define-color green {{ green }};
+@define-color yellow {{ yellow }};
+@define-color blue {{ blue }};
+@define-color cyan {{ cyan }};
+@define-color magenta {{ magenta }};

--- a/dotfiles/.config/themes/catppuccin-latte/colors.toml
+++ b/dotfiles/.config/themes/catppuccin-latte/colors.toml
@@ -1,0 +1,31 @@
+mode = "light"
+
+accent = "#1e66f5"
+selection = "#ccd0da"
+muted = "#acb0be"
+
+background = "#eff1f5"
+dark_background = "#e3e4e8"
+darker_background = "#d7d8dc"
+lighter_background = "#dce0e8"
+
+foreground = "#4c4f69"
+dark_foreground = "#9ca0b0"
+light_foreground = "#5c5f77"
+bright_foreground = "#4c4f69"
+
+red = "#d20f39"
+yellow = "#df8e1d"
+orange = "#d84e2b"
+green = "#40a02b"
+cyan = "#179299"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+brown = "#6c2715"
+
+bright_red = "#d20f39"
+bright_yellow = "#df8e1d"
+bright_green = "#40a02b"
+bright_cyan = "#179299"
+bright_blue = "#1e66f5"
+bright_magenta = "#ea76cb"

--- a/dotfiles/.config/themes/catppuccin/colors.toml
+++ b/dotfiles/.config/themes/catppuccin/colors.toml
@@ -1,0 +1,31 @@
+mode = "dark"
+
+accent = "#89b4fa"
+selection = "#45475a"
+muted = "#585b70"
+
+background = "#1e1e2e"
+dark_background = "#161622"
+darker_background = "#101019"
+lighter_background = "#313244"
+
+foreground = "#cdd6f4"
+dark_foreground = "#6c7086"
+light_foreground = "#bac2de"
+bright_foreground = "#cdd6f4"
+
+red = "#f38ba8"
+yellow = "#f9e2af"
+orange = "#f6b6ab"
+green = "#a6e3a1"
+cyan = "#94e2d5"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+brown = "#7b5b55"
+
+bright_red = "#f38ba8"
+bright_yellow = "#f9e2af"
+bright_green = "#a6e3a1"
+bright_cyan = "#94e2d5"
+bright_blue = "#89b4fa"
+bright_magenta = "#f5c2e7"

--- a/dotfiles/.config/themes/gruvbox/colors.toml
+++ b/dotfiles/.config/themes/gruvbox/colors.toml
@@ -1,0 +1,31 @@
+mode = "dark"
+
+accent = "#7daea3"
+selection = "#504945"
+muted = "#665c54"
+
+background = "#282828"
+dark_background = "#1e1e1e"
+darker_background = "#161616"
+lighter_background = "#3c3836"
+
+foreground = "#d4be98"
+dark_foreground = "#7c6f64"
+light_foreground = "#bdae93"
+bright_foreground = "#d4be98"
+
+red = "#ea6962"
+yellow = "#d8a657"
+orange = "#e1875c"
+green = "#a9b665"
+cyan = "#89b482"
+blue = "#7daea3"
+magenta = "#d3869b"
+brown = "#70432e"
+
+bright_red = "#ea6962"
+bright_yellow = "#d8a657"
+bright_green = "#a9b665"
+bright_cyan = "#89b482"
+bright_blue = "#7daea3"
+bright_magenta = "#d3869b"

--- a/dotfiles/.config/themes/nord/colors.toml
+++ b/dotfiles/.config/themes/nord/colors.toml
@@ -1,0 +1,31 @@
+mode = "dark"
+
+accent = "#81a1c1"
+selection = "#434c5e"
+muted = "#4c566a"
+
+background = "#2e3440"
+dark_background = "#222730"
+darker_background = "#191c23"
+lighter_background = "#3b4252"
+
+foreground = "#d8dee9"
+dark_foreground = "#667080"
+light_foreground = "#adb5c4"
+bright_foreground = "#d8dee9"
+
+red = "#bf616a"
+yellow = "#ebcb8b"
+orange = "#d5967a"
+green = "#a3be8c"
+cyan = "#88c0d0"
+blue = "#81a1c1"
+magenta = "#b48ead"
+brown = "#6a4b3d"
+
+bright_red = "#bf616a"
+bright_yellow = "#ebcb8b"
+bright_green = "#a3be8c"
+bright_cyan = "#8fbcbb"
+bright_blue = "#81a1c1"
+bright_magenta = "#b48ead"

--- a/dotfiles/.config/themes/tokyo-night/colors.toml
+++ b/dotfiles/.config/themes/tokyo-night/colors.toml
@@ -1,0 +1,31 @@
+mode = "dark"
+
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+
+background = "#1a1b26"
+dark_background = "#13141c"
+darker_background = "#0e0e14"
+lighter_background = "#24283b"
+
+foreground = "#a9b1d6"
+dark_foreground = "#565f89"
+light_foreground = "#b4bee6"
+bright_foreground = "#c0caf5"
+
+red = "#f7768e"
+yellow = "#e0af68"
+orange = "#eb927b"
+green = "#9ece6a"
+cyan = "#449dab"
+blue = "#7aa2f7"
+magenta = "#ad8ee6"
+brown = "#75493d"
+
+bright_red = "#ff7a93"
+bright_yellow = "#ff9e64"
+bright_green = "#b9f27c"
+bright_cyan = "#0db9d7"
+bright_blue = "#7da6ff"
+bright_magenta = "#bb9af7"

--- a/dotfiles/.local/bin/fcitx5-theme-sync
+++ b/dotfiles/.local/bin/fcitx5-theme-sync
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 config_theme="${XDG_CONFIG_HOME:-$HOME/.config}/theme/colors.toml"
-state_theme="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/current/theme/colors.toml"
+state_theme="${XDG_STATE_HOME:-$HOME/.local/state}/theme/colors.toml"
 
 if [[ -f "$config_theme" ]]; then
 	colors_file="$config_theme"
@@ -174,8 +174,6 @@ fi
 
 if systemctl --user is-active --quiet fcitx5.service 2>/dev/null; then
 	systemctl --user restart fcitx5.service
-elif systemctl --user is-active --quiet omarchy-fcitx5.service 2>/dev/null; then
-	systemctl --user restart omarchy-fcitx5.service
 elif pgrep -x fcitx5 >/dev/null; then
 	pkill -x fcitx5 && nohup /usr/bin/fcitx5 >/dev/null 2>&1 &
 fi

--- a/dotfiles/.local/bin/theme-menu
+++ b/dotfiles/.local/bin/theme-menu
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Interactive theme selector for River desktop using fuzzel or bemenu
+set -euo pipefail
+
+themes=$(theme-set --list | sed 's/^[ *]*//')
+if [[ -z "$themes" ]]; then
+	printf 'No themes found\n' >&2
+	exit 1
+fi
+
+if command -v fuzzel &>/dev/null; then
+	selected=$(echo "$themes" | fuzzel --dmenu --prompt "Theme: ")
+elif command -v bemenu &>/dev/null; then
+	selected=$(echo "$themes" | bemenu -p "Theme: ")
+else
+	selected=$(echo "$themes" | head -1)
+fi
+
+if [[ -n "${selected:-}" ]]; then
+	theme-set "$selected"
+fi

--- a/dotfiles/.local/bin/theme-set
+++ b/dotfiles/.local/bin/theme-set
@@ -59,17 +59,31 @@ def render_value(val: str, modifier: str | None) -> str:
 
 
 def render_template(template_text: str, colors: dict[str, str]) -> str:
-    # Match {{ key }} or {{ key_modifier }} or {{ key | modifier }}
-    pattern = re.compile(
-        r"\{\{\s*([a-zA-Z0-9_]+)(?:(?:_([a-zA-Z0-9_:]+))|(?:\s*\|\s*([a-zA-Z0-9_:]+)))?\s*\}\}"
-    )
+    pattern = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
 
     def replace_match(m: re.Match[str]) -> str:
-        key = m.group(1)
-        modifier = m.group(2) or m.group(3)
+        expr = m.group(1).strip()
+        if "|" in expr:
+            parts = expr.split("|", 1)
+            key = parts[0].strip()
+            mod = parts[1].strip()
+        else:
+            key = expr
+            mod = None
+            for suffix in ("strip", "rgb", "rgba", "alpha_hex"):
+                if expr.endswith(f"_{suffix}"):
+                    key = expr[: -len(suffix) - 1]
+                    mod = suffix
+                    break
+                elif f"_{suffix}:" in expr:
+                    idx = expr.index(f"_{suffix}:")
+                    key = expr[:idx]
+                    mod = expr[idx + 1 :]
+                    break
+
         if key in colors:
             val = str(colors[key])
-            return render_value(val, modifier)
+            return render_value(val, mod)
         return m.group(0)
 
     return pattern.sub(replace_match, template_text)

--- a/dotfiles/.local/bin/theme-set
+++ b/dotfiles/.local/bin/theme-set
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Universal Semantic Theme Switcher for Arch Linux + River Desktop.
+
+Parses colors.toml palettes, renders template files from ~/.config/themed/,
+updates ~/.local/state/theme, and broadcasts reload signals to desktop components.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+
+def get_config_dir() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    cfg = Path(xdg) if xdg else Path.home() / ".config"
+    if not (cfg / "themes").is_dir():
+        repo_cfg = Path(__file__).resolve().parent.parent.parent / ".config"
+        if (repo_cfg / "themes").is_dir():
+            return repo_cfg
+    return cfg
+
+
+def get_state_dir() -> Path:
+    xdg = os.environ.get("XDG_STATE_HOME")
+    return Path(xdg) if xdg else Path.home() / ".local" / "state"
+
+
+def hex_to_rgb(hex_str: str) -> tuple[int, int, int]:
+    h = hex_str.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def render_value(val: str, modifier: str | None) -> str:
+    if not modifier:
+        return val
+    if modifier == "strip":
+        return val.lstrip("#")
+    if modifier == "rgb":
+        r, g, b = hex_to_rgb(val)
+        return f"{r},{g},{b}"
+    if modifier.startswith("rgba:"):
+        alpha = modifier.split(":", 1)[1]
+        r, g, b = hex_to_rgb(val)
+        return f"rgba({r},{g},{b},{alpha})"
+    if modifier.startswith("alpha_hex:"):
+        # e.g. alpha_hex:dd
+        a_hex = modifier.split(":", 1)[1]
+        return val.lstrip("#") + a_hex
+    return val
+
+
+def render_template(template_text: str, colors: dict[str, str]) -> str:
+    # Match {{ key }} or {{ key_modifier }} or {{ key | modifier }}
+    pattern = re.compile(
+        r"\{\{\s*([a-zA-Z0-9_]+)(?:(?:_([a-zA-Z0-9_:]+))|(?:\s*\|\s*([a-zA-Z0-9_:]+)))?\s*\}\}"
+    )
+
+    def replace_match(m: re.Match[str]) -> str:
+        key = m.group(1)
+        modifier = m.group(2) or m.group(3)
+        if key in colors:
+            val = str(colors[key])
+            return render_value(val, modifier)
+        return m.group(0)
+
+    return pattern.sub(replace_match, template_text)
+
+
+def extract_target(template_text: str) -> Path | None:
+    for line in template_text.splitlines()[:5]:
+        line = line.strip()
+        m = re.match(
+            r"^(?:#|//|/\*|--)\s*TARGET:\s*([^\s\*]+)(?:\s*\*\/)?$", line
+        )
+        if m:
+            raw_path = m.group(1).strip()
+            return Path(os.path.expanduser(raw_path))
+    return None
+
+
+def atomic_write(target: Path, content: str, mode: int = 0o644) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=target.parent,
+        prefix=f".{target.name}.tmp",
+        delete=False,
+    ) as f:
+        f.write(content)
+        tmp_path = Path(f.name)
+    tmp_path.chmod(mode)
+    os.replace(tmp_path, target)
+
+
+def list_themes(themes_dir: Path) -> list[str]:
+    if not themes_dir.is_dir():
+        return []
+    result = []
+    for d in sorted(themes_dir.iterdir()):
+        if d.is_dir() and (d / "colors.toml").is_file():
+            result.append(d.name)
+    return result
+
+
+def get_current_theme(state_dir: Path) -> str | None:
+    name_file = state_dir / "theme" / "current.name"
+    if name_file.is_file():
+        return name_file.read_text().strip()
+    link = state_dir / "theme"
+    if link.is_symlink():
+        target = link.resolve()
+        return target.name
+    return None
+
+
+def broadcast_reloads() -> None:
+    # 1. Waybar CSS reload (SIGUSR2)
+    subprocess.run(["pkill", "-SIGUSR2", "waybar"], stderr=subprocess.DEVNULL)
+
+    # 2. Fnott reload (SIGUSR1)
+    subprocess.run(["pkill", "-SIGUSR1", "fnott"], stderr=subprocess.DEVNULL)
+
+    # 3. Fcitx5 theme sync
+    fcitx_sync = shutil.which("fcitx5-theme-sync")
+    if fcitx_sync:
+        subprocess.run([fcitx_sync], stderr=subprocess.DEVNULL)
+
+    # 4. Herdr theme sync
+    herdr_sync = shutil.which("theme-sync-herdr")
+    if herdr_sync:
+        subprocess.run([herdr_sync], stderr=subprocess.DEVNULL)
+
+    # 5. River theme script execution (if WAYLAND_DISPLAY is active)
+    if os.environ.get("WAYLAND_DISPLAY"):
+        river_theme = get_config_dir() / "river" / "theme.sh"
+        if river_theme.is_file() and os.access(river_theme, os.X_OK):
+            subprocess.run([str(river_theme)], stderr=subprocess.DEVNULL)
+
+
+def apply_theme(theme_name: str) -> None:
+    config_dir = get_config_dir()
+    state_dir = get_state_dir()
+    theme_path = config_dir / "themes" / theme_name
+    colors_file = theme_path / "colors.toml"
+
+    if not colors_file.is_file():
+        print(
+            f"Error: Theme '{theme_name}' not found at {colors_file}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(colors_file, "rb") as f:
+        colors_data = tomllib.load(f)
+
+    # Flatten strings/scalars into string map
+    colors: dict[str, str] = {
+        k: str(v) for k, v in colors_data.items() if isinstance(v, (str, int))
+    }
+
+    # 1. Render templates in ~/.config/themed/
+    themed_dir = config_dir / "themed"
+    rendered_count = 0
+    if themed_dir.is_dir():
+        for tpl_path in sorted(themed_dir.glob("*.tpl")):
+            content = tpl_path.read_text()
+            target_path = extract_target(content)
+            rendered = render_template(content, colors)
+
+            if target_path:
+                is_exec = tpl_path.suffix == ".sh.tpl" or target_path.suffix in (
+                    ".sh",
+                    ".bash",
+                )
+                atomic_write(
+                    target_path, rendered, mode=0o755 if is_exec else 0o644
+                )
+                rendered_count += 1
+
+    # 2. Update state directory: ~/.local/state/theme
+    theme_state_dir = state_dir / "theme"
+    theme_state_dir.mkdir(parents=True, exist_ok=True)
+
+    # Atomically link current theme and copy active colors.toml
+    atomic_write(theme_state_dir / "colors.toml", colors_file.read_text())
+    atomic_write(theme_state_dir / "current.name", f"{theme_name}\n")
+
+    # Symlink ~/.local/state/theme/current -> theme_path
+    current_symlink = theme_state_dir / "current"
+    if current_symlink.is_symlink() or current_symlink.is_file():
+        current_symlink.unlink()
+    try:
+        current_symlink.symlink_to(theme_path)
+    except OSError:
+        pass
+
+    # 3. Broadcast reload signals
+    broadcast_reloads()
+
+    print(
+        f"✓ Applied theme '{theme_name}' ({rendered_count} template(s) rendered)"
+    )
+
+
+def main() -> None:
+    config_dir = get_config_dir()
+    state_dir = get_state_dir()
+    themes_dir = config_dir / "themes"
+
+    if len(sys.argv) < 2:
+        curr = get_current_theme(state_dir)
+        print("Usage: theme-set <theme-name> | --list | --current | --refresh")
+        if curr:
+            print(f"Active theme: {curr}")
+        sys.exit(0)
+
+    arg = sys.argv[1]
+    if arg in ("-l", "--list"):
+        for t in list_themes(themes_dir):
+            prefix = "* " if t == get_current_theme(state_dir) else "  "
+            print(f"{prefix}{t}")
+    elif arg in ("-c", "--current"):
+        curr = get_current_theme(state_dir)
+        print(curr or "none")
+    elif arg in ("-r", "--refresh"):
+        curr = get_current_theme(state_dir)
+        if not curr:
+            print(
+                "Error: No active theme found to refresh.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        apply_theme(curr)
+    elif arg in ("-h", "--help", "help"):
+        print("Usage: theme-set <theme-name> | --list | --current | --refresh")
+    else:
+        apply_theme(arg)
+
+
+if __name__ == "__main__":
+    main()

--- a/dotfiles/.local/bin/theme-sync-herdr
+++ b/dotfiles/.local/bin/theme-sync-herdr
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Sync herdr [theme.custom] colors from the current Omarchy theme.
-# Maps ~/.local/state/omarchy/current/theme/colors.toml tokens to herdr's
+# Sync herdr [theme.custom] colors from the current theme palette.
+# Maps ~/.local/state/theme/colors.toml tokens to herdr's
 # semantic slots and replaces the marked block in herdr config.toml.
 #
 # Usage: theme-sync-herdr
@@ -9,13 +9,13 @@
 
 set -e
 
-COLORS="${COLORS:-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/current/theme/colors.toml}"
+COLORS="${COLORS:-${XDG_STATE_HOME:-$HOME/.local/state}/theme/colors.toml}"
 CONFIG="${CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}"
 BEGIN_MARK="# --- BEGIN herdr theme ---"
 END_MARK="# --- END herdr theme ---"
 
 if [[ ! -f $COLORS ]]; then
-	echo "No Omarchy colors.toml at $COLORS" >&2
+	echo "No colors.toml at $COLORS" >&2
 	exit 1
 fi
 

--- a/mise/conf.d/30-dotfiles.toml
+++ b/mise/conf.d/30-dotfiles.toml
@@ -37,6 +37,8 @@ dotfiles.default_mode = "symlink"
 "~/.config/retroarch" = { source = "../../dotfiles/.config/retroarch", mode = "symlink-each" }
 "~/.config/systemd" = { source = "../../dotfiles/.config/systemd", mode = "symlink-each" }
 "~/.config/tensaku" = { source = "../../dotfiles/.config/tensaku", mode = "symlink-each" }
+"~/.config/themes" = { source = "../../dotfiles/.config/themes", mode = "symlink-each" }
+"~/.config/themed" = { source = "../../dotfiles/.config/themed", mode = "symlink-each" }
 "~/.config/tmux" = { source = "../../dotfiles/.config/tmux", mode = "symlink-each" }
 "~/.config/uv" = { source = "../../dotfiles/.config/uv", mode = "symlink-each" }
 "~/.config/vinput" = { source = "../../dotfiles/.config/vinput", mode = "symlink-each", exclude = [


### PR DESCRIPTION
Closes #33

### Implementation Tasks
- [x] 1. Add starter theme palettes (tokyo-night, catppuccin, gruvbox, nord) in dotfiles/.config/themes
- [x] 2. Implement core theme-set rendering script in dotfiles/.local/bin/theme-set
- [x] 3. Create desktop component templates (foot, fuzzel, waybar, fnott, river) in dotfiles/.config/themed
- [x] 4. Wire theme state and dotfile mappings, test theme switching in VM sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a universal theme switcher with support for applying, listing, refreshing, and previewing themes.
  - Added an interactive theme selection menu with Fuzzel, Bemenu, and fallback support.
  - Added Catppuccin, Catppuccin Latte, Gruvbox, Nord, and Tokyo Night themes.
  - Added theme integration for Waybar, Foot, Fuzzel, Fnott, River, and related desktop components.

- **Updates**
  - Simplified theme state paths and Fcitx5 synchronization.
  - Added automatic management of shared theme configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->