### PR TITLE
refactor(theme): rewrite arch-theme-set in pure bash and streamline live push (#39)

### DIFF
--- a/dotfiles/.local/bin/arch-live-push
+++ b/dotfiles/.local/bin/arch-live-push
@@ -55,13 +55,13 @@ unmute_audio() {
 }
 
 boost_hardware() {
-	command -v intel-gpu-freq >/dev/null 2>&1 && intel-gpu-freq max >/dev/null 2>&1 || true
-	command -v thinkpad-fan >/dev/null 2>&1 && thinkpad-fan max >/dev/null 2>&1 || true
+	command -v arch-hw-gpu >/dev/null 2>&1 && arch-hw-gpu max >/dev/null 2>&1 || true
+	command -v arch-hw-fan >/dev/null 2>&1 && arch-hw-fan full-speed >/dev/null 2>&1 || true
 }
 
 restore_hardware() {
-	command -v intel-gpu-freq >/dev/null 2>&1 && intel-gpu-freq auto >/dev/null 2>&1 || true
-	command -v thinkpad-fan >/dev/null 2>&1 && thinkpad-fan auto >/dev/null 2>&1 || true
+	command -v arch-hw-gpu >/dev/null 2>&1 && arch-hw-gpu auto >/dev/null 2>&1 || true
+	command -v arch-hw-fan >/dev/null 2>&1 && arch-hw-fan auto >/dev/null 2>&1 || true
 }
 
 open_danmaku() {
@@ -75,13 +75,13 @@ close_danmaku() {
 }
 
 start_stream() {
-	local target="${1:-portal}" capture_target rc
+	local target="${1:-screen}" capture_target="screen" rc
 
 	ensure_dirs
 	check_deps || return 4
 	case "$target" in
-	full) capture_target=screen ;;
-	*) capture_target=$target ;;
+	portal) capture_target="portal" ;;
+	*) capture_target="screen" ;;
 	esac
 
 	if is_active; then
@@ -184,11 +184,11 @@ is-active)
 	is_active
 	;;
 config)
-	exec "${OMARCHY_PATH:-/usr/share/omarchy}"/bin/omarchy-shell xifan.livestream-config toggle
+	exec "${EDITOR:-nvim}" "$CONFIG_FILE"
 	;;
 -h | --help)
 	cat <<EOF
-Usage: livestream [start|stop|toggle|status|is-active|config] [portal|full]
+Usage: arch live push [start|stop|toggle|status|is-active|config] [screen|portal]
 EOF
 	;;
 *)

--- a/dotfiles/.local/bin/arch-theme-set
+++ b/dotfiles/.local/bin/arch-theme-set
@@ -1,267 +1,245 @@
-#!/usr/bin/env -S PYTHONDONTWRITEBYTECODE=1 python3
+#!/usr/bin/env bash
 # arch:summary=Apply or switch desktop semantic color theme
 # arch:args=<theme-name> | --list | --current | --refresh
 # arch:examples=arch theme set tokyo-night | arch theme set --list
-"""Universal Semantic Theme Switcher for Arch Linux + River Desktop.
+set -euo pipefail
 
-Parses colors.toml palettes, renders template files from ~/.config/themed/,
-updates ~/.local/state/theme, and broadcasts reload signals to desktop components.
-"""
+get_config_dir() {
+	local xdg="${XDG_CONFIG_HOME:-$HOME/.config}"
+	if [[ -d "$xdg/themes" ]]; then
+		printf '%s' "$xdg"
+		return 0
+	fi
+	local repo_cfg
+	repo_cfg="$(dirname "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")")/.config"
+	if [[ -d "$repo_cfg/themes" ]]; then
+		printf '%s' "$repo_cfg"
+		return 0
+	fi
+	printf '%s' "$xdg"
+}
 
-from __future__ import annotations
+get_state_dir() {
+	printf '%s' "${XDG_STATE_HOME:-$HOME/.local/state}"
+}
 
-import os
-import re
-import shutil
-import subprocess
-import sys
-import tempfile
-import tomllib
-from pathlib import Path
+get_current_theme() {
+	local state_dir
+	state_dir="$(get_state_dir)"
+	local name_file="$state_dir/theme/current.name"
+	if [[ -f "$name_file" ]]; then
+		cat "$name_file"
+		return 0
+	fi
+	local link="$state_dir/theme/current"
+	if [[ -L "$link" ]]; then
+		basename "$(readlink -f "$link")"
+		return 0
+	fi
+	return 1
+}
 
+list_themes() {
+	local themes_dir="$1"
+	local curr
+	curr="$(get_current_theme || true)"
+	for d in "$themes_dir"/*; do
+		if [[ -d "$d" && -f "$d/colors.toml" ]]; then
+			local name="${d##*/}"
+			local prefix="  "
+			[[ "$name" == "$curr" ]] && prefix="* "
+			printf '%s%s\n' "$prefix" "$name"
+		fi
+	done
+}
 
-def get_config_dir() -> Path:
-    xdg = os.environ.get("XDG_CONFIG_HOME")
-    cfg = Path(xdg) if xdg else Path.home() / ".config"
-    if not (cfg / "themes").is_dir():
-        repo_cfg = Path(__file__).resolve().parent.parent.parent / ".config"
-        if (repo_cfg / "themes").is_dir():
-            return repo_cfg
-    return cfg
+broadcast_reloads() {
+	pkill -SIGUSR2 waybar 2>/dev/null || true
+	pkill -SIGUSR1 fnott 2>/dev/null || true
 
+	local fcitx_sync
+	fcitx_sync="$(command -v arch-theme-sync-fcitx5 || command -v fcitx5-theme-sync || true)"
+	if [[ -n "$fcitx_sync" ]]; then
+		"$fcitx_sync" >/dev/null 2>&1 || true
+	fi
 
-def get_state_dir() -> Path:
-    xdg = os.environ.get("XDG_STATE_HOME")
-    return Path(xdg) if xdg else Path.home() / ".local" / "state"
+	local herdr_sync
+	herdr_sync="$(command -v arch-theme-sync-herdr || command -v theme-sync-herdr || true)"
+	if [[ -n "$herdr_sync" ]]; then
+		"$herdr_sync" >/dev/null 2>&1 || true
+	fi
 
+	if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+		local cfg
+		cfg="$(get_config_dir)"
+		local river_theme="$cfg/river/theme.sh"
+		if [[ -x "$river_theme" ]]; then
+			"$river_theme" >/dev/null 2>&1 || true
+		fi
+	fi
+}
 
-def hex_to_rgb(hex_str: str) -> tuple[int, int, int]:
-    h = hex_str.lstrip("#")
-    if len(h) == 3:
-        h = "".join(c * 2 for c in h)
-    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+render_template() {
+	local colors_file="$1"
+	local tpl_file="$2"
+	local target_file="$3"
+	local is_exec="${4:-0}"
 
+	mkdir -p "$(dirname "$target_file")"
+	local tmp
+	tmp=$(mktemp -p "$(dirname "$target_file")" ".${target_file##*/}.tmp.XXXXXX")
 
-def render_value(val: str, modifier: str | None) -> str:
-    if not modifier:
+	awk '
+    function hex2dec(hex,   chars, val, i) {
+        hex = tolower(hex)
+        chars = "0123456789abcdef"
+        val = 0
+        for (i = 1; i <= length(hex); i++) {
+            val = val * 16 + (index(chars, substr(hex, i, 1)) - 1)
+        }
         return val
-    if modifier == "strip":
-        return val.lstrip("#")
-    if modifier == "rgb":
-        r, g, b = hex_to_rgb(val)
-        return f"{r},{g},{b}"
-    if modifier.startswith("rgba:"):
-        alpha = modifier.split(":", 1)[1]
-        r, g, b = hex_to_rgb(val)
-        return f"rgba({r},{g},{b},{alpha})"
-    if modifier.startswith("alpha_hex:"):
-        # e.g. alpha_hex:dd
-        a_hex = modifier.split(":", 1)[1]
-        return val.lstrip("#") + a_hex
-    return val
-
-
-def render_template(template_text: str, colors: dict[str, str]) -> str:
-    pattern = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
-
-    def replace_match(m: re.Match[str]) -> str:
-        expr = m.group(1).strip()
-        if "|" in expr:
-            parts = expr.split("|", 1)
-            key = parts[0].strip()
-            mod = parts[1].strip()
-        else:
-            key = expr
-            mod = None
-            for suffix in ("strip", "rgb", "rgba", "alpha_hex"):
-                if expr.endswith(f"_{suffix}"):
-                    key = expr[: -len(suffix) - 1]
-                    mod = suffix
-                    break
-                elif f"_{suffix}:" in expr:
-                    idx = expr.index(f"_{suffix}:")
-                    key = expr[:idx]
-                    mod = expr[idx + 1 :]
-                    break
-
-        if key in colors:
-            val = str(colors[key])
-            return render_value(val, mod)
-        return m.group(0)
-
-    return pattern.sub(replace_match, template_text)
-
-
-def extract_target(template_text: str) -> Path | None:
-    for line in template_text.splitlines()[:5]:
-        line = line.strip()
-        m = re.match(
-            r"^(?:#|//|/\*|--)\s*TARGET:\s*([^\s\*]+)(?:\s*\*\/)?$", line
-        )
-        if m:
-            raw_path = m.group(1).strip()
-            return Path(os.path.expanduser(raw_path))
-    return None
-
-
-def atomic_write(target: Path, content: str, mode: int = 0o644) -> None:
-    target.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        dir=target.parent,
-        prefix=f".{target.name}.tmp",
-        delete=False,
-    ) as f:
-        f.write(content)
-        tmp_path = Path(f.name)
-    tmp_path.chmod(mode)
-    os.replace(tmp_path, target)
-
-
-def list_themes(themes_dir: Path) -> list[str]:
-    if not themes_dir.is_dir():
-        return []
-    result = []
-    for d in sorted(themes_dir.iterdir()):
-        if d.is_dir() and (d / "colors.toml").is_file():
-            result.append(d.name)
-    return result
-
-
-def get_current_theme(state_dir: Path) -> str | None:
-    name_file = state_dir / "theme" / "current.name"
-    if name_file.is_file():
-        return name_file.read_text().strip()
-    link = state_dir / "theme"
-    if link.is_symlink():
-        target = link.resolve()
-        return target.name
-    return None
-
-
-def broadcast_reloads() -> None:
-    # 1. Waybar CSS reload (SIGUSR2)
-    subprocess.run(["pkill", "-SIGUSR2", "waybar"], stderr=subprocess.DEVNULL)
-
-    # 2. Fnott reload (SIGUSR1)
-    subprocess.run(["pkill", "-SIGUSR1", "fnott"], stderr=subprocess.DEVNULL)
-
-    # 3. Fcitx5 theme sync
-    fcitx_sync = shutil.which("arch-theme-sync-fcitx5") or shutil.which("fcitx5-theme-sync")
-    if fcitx_sync:
-        subprocess.run([fcitx_sync], stderr=subprocess.DEVNULL)
-
-    # 4. Herdr theme sync
-    herdr_sync = shutil.which("arch-theme-sync-herdr") or shutil.which("theme-sync-herdr")
-    if herdr_sync:
-        subprocess.run([herdr_sync], stderr=subprocess.DEVNULL)
-
-    # 5. River theme script execution (if WAYLAND_DISPLAY is active)
-    if os.environ.get("WAYLAND_DISPLAY"):
-        river_theme = get_config_dir() / "river" / "theme.sh"
-        if river_theme.is_file() and os.access(river_theme, os.X_OK):
-            subprocess.run([str(river_theme)], stderr=subprocess.DEVNULL)
-
-
-def apply_theme(theme_name: str) -> None:
-    config_dir = get_config_dir()
-    state_dir = get_state_dir()
-    theme_path = config_dir / "themes" / theme_name
-    colors_file = theme_path / "colors.toml"
-
-    if not colors_file.is_file():
-        print(
-            f"Error: Theme '{theme_name}' not found at {colors_file}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    with open(colors_file, "rb") as f:
-        colors_data = tomllib.load(f)
-
-    # Flatten strings/scalars into string map
-    colors: dict[str, str] = {
-        k: str(v) for k, v in colors_data.items() if isinstance(v, (str, int))
     }
 
-    # 1. Render templates in ~/.config/themed/
-    themed_dir = config_dir / "themed"
-    rendered_count = 0
-    if themed_dir.is_dir():
-        for tpl_path in sorted(themed_dir.glob("*.tpl")):
-            content = tpl_path.read_text()
-            target_path = extract_target(content)
-            rendered = render_template(content, colors)
+    function hex2rgb(hex,   r, g, b) {
+        sub(/^#/, "", hex)
+        r = hex2dec(substr(hex, 1, 2))
+        g = hex2dec(substr(hex, 3, 2))
+        b = hex2dec(substr(hex, 5, 2))
+        return r "," g "," b
+    }
 
-            if target_path:
-                is_exec = tpl_path.suffix == ".sh.tpl" or target_path.suffix in (
-                    ".sh",
-                    ".bash",
-                )
-                atomic_write(
-                    target_path, rendered, mode=0o755 if is_exec else 0o644
-                )
-                rendered_count += 1
+    NR == FNR {
+        if ($0 ~ /^[a-z_]+[ \t]*=/) {
+            split($0, parts, "=")
+            gsub(/[ \t]/, "", parts[1])
+            gsub(/[ \t"\047]/, "", parts[2])
+            colors[parts[1]] = parts[2]
+        }
+        next
+    }
 
-    # 2. Update state directory: ~/.local/state/theme
-    theme_state_dir = state_dir / "theme"
-    theme_state_dir.mkdir(parents=True, exist_ok=True)
+    {
+        line = $0
+        for (k in colors) {
+            c = colors[k]
+            c_strip = c
+            sub(/^#/, "", c_strip)
+            c_rgb = hex2rgb(c)
 
-    # Atomically link current theme and copy active colors.toml
-    atomic_write(theme_state_dir / "colors.toml", colors_file.read_text())
-    atomic_write(theme_state_dir / "current.name", f"{theme_name}\n")
+            pat_plain = "\\{\\{[ \t]*" k "[ \t]*\\}\\}"
+            pat_strip = "\\{\\{[ \t]*" k "(_strip|[ \t]*\\|[ \t]*strip)[ \t]*\\}\\}"
+            pat_rgb   = "\\{\\{[ \t]*" k "(_rgb|[ \t]*\\|[ \t]*rgb)[ \t]*\\}\\}"
 
-    # Symlink ~/.local/state/theme/current -> theme_path
-    current_symlink = theme_state_dir / "current"
-    if current_symlink.is_symlink() or current_symlink.is_file():
-        current_symlink.unlink()
-    try:
-        current_symlink.symlink_to(theme_path)
-    except OSError:
-        pass
+            gsub(pat_strip, c_strip, line)
+            gsub(pat_rgb, c_rgb, line)
+            gsub(pat_plain, c, line)
+        }
+        print line
+    }
+    ' "$colors_file" "$tpl_file" >"$tmp"
 
-    # 3. Broadcast reload signals
-    broadcast_reloads()
+	if [[ "$is_exec" -eq 1 ]]; then
+		chmod 0755 "$tmp"
+	else
+		chmod 0644 "$tmp"
+	fi
+	mv -f "$tmp" "$target_file"
+}
 
-    print(
-        f"✓ Applied theme '{theme_name}' ({rendered_count} template(s) rendered)"
-    )
+extract_target() {
+	local file="$1"
+	local line
+	line=$(head -n 5 "$file" | grep -E '^(#|//|/\*|--)[[:space:]]*TARGET:[[:space:]]*' | head -1 || true)
+	if [[ -n "$line" ]]; then
+		local raw
+		raw=$(echo "$line" | sed -E 's/^(#|\/\/|\/\*|--)[[:space:]]*TARGET:[[:space:]]*//; s/[[:space:]]*\*\/$//')
+		raw="${raw/#\~/$HOME}"
+		printf '%s' "$raw"
+	fi
+}
 
+apply_theme() {
+	local theme_name="$1"
+	local cfg
+	cfg="$(get_config_dir)"
+	local state_dir
+	state_dir="$(get_state_dir)"
+	local theme_path="$cfg/themes/$theme_name"
+	local colors_file="$theme_path/colors.toml"
 
-def main() -> None:
-    config_dir = get_config_dir()
-    state_dir = get_state_dir()
-    themes_dir = config_dir / "themes"
+	if [[ ! -f "$colors_file" ]]; then
+		printf 'Error: Theme "%s" not found at %s\n' "$theme_name" "$colors_file" >&2
+		return 1
+	fi
 
-    if len(sys.argv) < 2:
-        curr = get_current_theme(state_dir)
-        print("Usage: theme-set <theme-name> | --list | --current | --refresh")
-        if curr:
-            print(f"Active theme: {curr}")
-        sys.exit(0)
+	local themed_dir="$cfg/themed"
+	local rendered_count=0
+	if [[ -d "$themed_dir" ]]; then
+		for tpl in "$themed_dir"/*.tpl; do
+			[[ -f "$tpl" ]] || continue
+			local target
+			target="$(extract_target "$tpl")"
+			if [[ -n "$target" ]]; then
+				local is_exec=0
+				if [[ "$tpl" == *.sh.tpl || "$target" == *.sh ]]; then
+					is_exec=1
+				fi
+				render_template "$colors_file" "$tpl" "$target" "$is_exec"
+				rendered_count=$((rendered_count + 1))
+			fi
+		done
+	fi
 
-    arg = sys.argv[1]
-    if arg in ("-l", "--list"):
-        for t in list_themes(themes_dir):
-            prefix = "* " if t == get_current_theme(state_dir) else "  "
-            print(f"{prefix}{t}")
-    elif arg in ("-c", "--current"):
-        curr = get_current_theme(state_dir)
-        print(curr or "none")
-    elif arg in ("-r", "--refresh"):
-        curr = get_current_theme(state_dir)
-        if not curr:
-            print(
-                "Error: No active theme found to refresh.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        apply_theme(curr)
-    elif arg in ("-h", "--help", "help"):
-        print("Usage: theme-set <theme-name> | --list | --current | --refresh")
-    else:
-        apply_theme(arg)
+	local theme_state="$state_dir/theme"
+	mkdir -p "$theme_state"
+	cp -f "$colors_file" "$theme_state/colors.toml"
+	printf '%s\n' "$theme_name" >"$theme_state/current.name"
 
+	local current_symlink="$theme_state/current"
+	rm -f "$current_symlink"
+	ln -s "$theme_path" "$current_symlink" 2>/dev/null || true
 
-if __name__ == "__main__":
-    main()
+	broadcast_reloads
+
+	printf '✓ Applied theme "%s" (%d template(s) rendered)\n' "$theme_name" "$rendered_count"
+}
+
+main() {
+	local cfg
+	cfg="$(get_config_dir)"
+	local themes_dir="$cfg/themes"
+
+	if [[ $# -lt 1 ]]; then
+		local curr
+		curr="$(get_current_theme || echo "none")"
+		printf 'Usage: arch-theme-set <theme-name> | --list | --current | --refresh\n'
+		printf 'Active theme: %s\n' "$curr"
+		return 0
+	fi
+
+	case "$1" in
+	-l | --list)
+		list_themes "$themes_dir"
+		;;
+	-c | --current)
+		get_current_theme || printf 'none\n'
+		;;
+	-r | --refresh)
+		local curr
+		curr="$(get_current_theme || true)"
+		if [[ -z "$curr" ]]; then
+			printf 'Error: No active theme found to refresh\n' >&2
+			return 1
+		fi
+		apply_theme "$curr"
+		;;
+	-h | --help | help)
+		printf 'Usage: arch-theme-set <theme-name> | --list | --current | --refresh\n'
+		;;
+	*)
+		apply_theme "$1"
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
Closes #39

### Implementation Tasks
- [x] 1. Rewrite arch-theme-set as a pure Bash and awk script
- [x] 2. Streamline arch-live-push target defaults and hardware boost calls
- [x] 3. Validate theme rendering, quality gates, and test in VM sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated livestream hardware controls for GPU and fan management.
  * Screen capture is now the default; portal capture must be selected explicitly.
  * The livestream configuration command now opens the configuration directly in the configured editor.
  * Updated command-line help to reflect the current `arch live push` syntax and capture options.
  * Reworked theme switching while maintaining theme detection, listing, rendering, state updates, and reload notifications.

* **Compatibility**
  * Some advanced color template modifiers and three-digit hex color formats are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->