### PR TITLE
docs(vm): document real-device input injection for the test VM (#41)

### DIFF
--- a/vms/arch-basic/README.md
+++ b/vms/arch-basic/README.md
@@ -48,11 +48,50 @@
 | `disk.qcow2`      | 系统盘（含所有快照）                             |
 | `OVMF_VARS.fd`    | UEFI NVRAM，保存 efibootmgr 启动项               |
 | `vm.sh`           | 本目录管理脚本                                   |
+| `hmp.py`          | 通过 QEMU HMP 向客户机注入真实输入的测试工具      |
 | `README.md`       | 本文件                                           |
 | `arch-basic.*`    | Quickemu 运行时生成（socket / pid / 日志 / `.sh`），可忽略 |
+
+## 向客户机注入输入（测试桌面组件时用）
+
+**不要用 `ydotool` / `wtype` 之类的合成输入设备。** 它们会在客户机里凭空
+多出一台虚拟输入设备（`libinput list-devices` 会多出 `ydotoold virtual
+device`），于是你测的就不再是用户真实走的输入路径，而且多设备并存会让指针
+归属变得不可预测。
+
+正确做法是复用 QEMU 自己的输入通道 — 事件直接进 `QEMU HID Tablet`，也就是
+物理鼠标驱动的同一台设备：
+
+```bash
+./hmp.py                                  # 查看鼠标设备列表（确认 * 在 #4）
+./hmp.py move <dx> <dy>                   # 相对移动指针
+./hmp.py cmd 'mouse_button 1'             # 左键按下（1=L, 2=R, 4=M），状态保持
+./hmp.py cmd 'mouse_button 0'             # 全部抬起
+./hmp.py cmd 'sendkey meta_l 3000'        # 按住 Super 3 秒（跨整个拖拽序列）
+./hmp.py drag-super 1 <dx> <dy>           # 按住 Super 拖左键
+./hmp.py wheel <dz>                       # 滚动滚轮
+```
+
+规范测试一个手势的写法：
+
+```bash
+# 1. 先把指针停到已知位置，并确认窗口管理器认为的 hover 目标
+./hmp.py move -3000 -3000 && ./hmp.py move 300 400
+ssh arch@127.0.0.1 -p 22220 'WAYLAND_DISPLAY=wayland-1 xrwm status'
+#   看 hovered_window_id，确认指针确实落在预期的窗口上，再动手势
+
+# 2. 再做手势，并对比手势前后的 status / 日志
+./hmp.py cmd 'sendkey meta_l 2500'
+./hmp.py cmd 'mouse_button 4' && sleep 0.5 && ./hmp.py cmd 'mouse_button 0'
+```
+
+> **踩过的坑**：如果手势"没生效"，先看 `hovered_window_id` 是不是 `null`。
+> 指针不在任何窗口上时，指针绑定照样会触发，但窗口管理器的 hover 目标是空，
+> 于是动作无处施加 —— 这不是绑定没注册，而是测试没有把指针放到窗口上。
 
 ## 备注
 
 - 官方 `basic` 镜像的 `sshd` 因缺 host key 启动失败；已用 `ssh-keygen -A` 修复并 `systemctl enable sshd`。
 - 原镜像用 GRUB（BIOS/UEFI 双支持）；已迁移为纯 UEFI + systemd-boot。
 - 宿主机依赖：`qemu-desktop`、`edk2-ovmf`、`swtpm`、`quickemu`。
+- HMP socket 只在 VM 运行时存在；`hmp.py` 默认连 `arch-basic-monitor.socket`。

--- a/vms/arch-basic/hmp.py
+++ b/vms/arch-basic/hmp.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Drive the arch-basic VM's real input devices through the QEMU HMP monitor.
+
+This intentionally avoids synthetic input devices (ydotool/uinput): the events
+go to the same QEMU HID Tablet the user's physical mouse drives, so what we
+verify is the real input path.
+
+Usage:
+    hmp.py cmd 'mouse_set 4' 'mouse_move 100 50'
+    hmp.py drag-super <button> <dx> <dy>       # Super held across a drag
+    hmp.py wheel <dz>
+"""
+
+import socket
+import sys
+import time
+
+SOCK = "/home/xifan/Code/arch-post-install/vms/arch-basic/arch-basic-monitor.socket"
+
+# QEMU HMP key names for held modifiers.
+KEY_SUPER = "meta_l"
+
+
+class Hmp:
+    def __init__(self, sock=SOCK):
+        self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.s.connect(sock)
+        time.sleep(0.3)
+        self._drain()
+
+    def _drain(self, wait=0.25):
+        self.s.settimeout(wait)
+        out = b""
+        try:
+            while True:
+                chunk = self.s.recv(65536)
+                if not chunk:
+                    break
+                out += chunk
+        except TimeoutError:
+            pass
+        finally:
+            self.s.settimeout(None)
+        return out.decode(errors="replace")
+
+    def cmd(self, line, wait=0.25):
+        self.s.sendall((line + "\n").encode())
+        time.sleep(0.05)
+        return self._drain(wait)
+
+    def close(self):
+        self.s.close()
+
+
+def selftest():
+    h = Hmp()
+    out = h.cmd("info mice", 0.8)
+    h.close()
+    print(out)
+
+
+def run(cmds):
+    h = Hmp()
+    for c in cmds:
+        h.cmd(c)
+    h.close()
+
+
+def drag_super(button, dx, dy, steps=3, key_hold_ms=4000):
+    """Hold Super, press `button`, drag by (dx,dy), release, release Super."""
+    h = Hmp()
+    # `sendkey` with a long hold returns immediately; the key stays down until
+    # the hold expires, which covers the whole mouse sequence below.
+    h.cmd(f"sendkey {KEY_SUPER} {key_hold_ms}")
+    time.sleep(0.3)
+    h.cmd("mouse_set 4")
+    h.cmd(f"mouse_button {button}")
+    time.sleep(0.3)
+    for _ in range(steps):
+        h.cmd(f"mouse_move {dx // steps} {dy // steps}")
+        time.sleep(0.25)
+    h.cmd("mouse_button 0")
+    time.sleep(0.2)
+    h.close()
+
+
+def wheel(dz, steps=1):
+    h = Hmp()
+    h.cmd("mouse_set 4")
+    for _ in range(steps):
+        h.cmd(f"mouse_move 0 0 {dz}")
+        time.sleep(0.25)
+    h.close()
+
+
+def move_to(dx, dy):
+    h = Hmp()
+    h.cmd("mouse_set 4")
+    h.cmd(f"mouse_move {dx} {dy}")
+    h.close()
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        selftest()
+    elif args[0] == "cmd":
+        run(args[1:])
+    elif args[0] == "drag-super":
+        drag_super(int(args[1]), int(args[2]), int(args[3]))
+    elif args[0] == "wheel":
+        wheel(int(args[1]), int(args[2]) if len(args) > 2 else 1)
+    elif args[0] == "move":
+        move_to(int(args[1]), int(args[2]))
+    else:
+        print(__doc__)
+        sys.exit(1)


### PR DESCRIPTION
Closes #41

### Implementation Tasks
- [x] 1. Add hmp.py HMP input harness for the test VM
- [x] 2. Document real-device input injection and its pitfalls in the VM README